### PR TITLE
meta: have a actually nix flake shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1729265718,
+        "narHash": "sha256-4HQI+6LsO3kpWTYuVGIzhJs1cetFcwT7quWCk/6rqeo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ccc0c2126893dd20963580b6478d1a10a4512185",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "BTCPay nix flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        dotnet-combined = (with pkgs.dotnetCorePackages;
+          combinePackages [ sdk_8_0 sdk_7_0 ]).overrideAttrs
+          (finalAttrs: previousAttrs: {
+            # This is needed to install workload in $HOME
+            # https://discourse.nixos.org/t/dotnet-maui-workload/20370/2
+
+            postBuild = (previousAttrs.postBuild or "") + ''
+               for i in $out/sdk/*
+               do
+                 i=$(basename $i)
+                 length=$(printf "%s" "$i" | wc -c)
+                 substring=$(printf "%s" "$i" | cut -c 1-$(expr $length - 2))
+                 i="$substring""00"
+                 mkdir -p $out/metadata/workloads/''${i/-*}
+                 touch $out/metadata/workloads/''${i/-*}/userlocal
+              done
+            '';
+          });
+      in rec {
+        packages = { dotnet = pkgs.dotnet-sdk; };
+
+        default = packages.dotnet;
+
+        DOTNET_ROOT = "${dotnet-combined}";
+
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [ dotnet-combined docker docker-compose ];
+
+          mkShellHook = ''
+            export DOTNET_ROOT=$HOME/.dotnet
+            export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools
+          '';
+        };
+      });
+}


### PR DESCRIPTION
This patch proposes to add a nix flake script that configures all that is needed to build the basic project.

The reason for this is to speed up the onboarding of a new person to the project who like me does not use C# to close a decade. However, I noted that on linux it is not easy to get up and running with dotnet and mui packages (See https://discourse.nixos.org/t/dotnet-maui-workload/20370/3)