### PR TITLE
Download logs

### DIFF
--- a/BTCPayApp.UI/Pages/Settings/AppLogsPage.razor
+++ b/BTCPayApp.UI/Pages/Settings/AppLogsPage.razor
@@ -1,10 +1,12 @@
 ﻿@attribute [Route(Routes.AppLogs)]
+@using System.Text
 @using BTCPayApp.Core.Contracts
 @using BTCPayApp.Core.Services
 @using BTCPayApp.UI.Components.Layout
 @using Serilog.Events
 @inject ConfigProvider ConfigProvider
 @inject LoggingService LogService
+@inject IJSRuntime JS
 
 <PageTitle>Application Logs</PageTitle>
 
@@ -46,7 +48,7 @@
     @if (HasLogs)
     {
         <div id="CtaContainer" class="container d-flex align-items-center justify-content-between">
-            <button type="button" class="btn btn-primary w-100" data-clipboard-target="#logs">Copy logs</button>
+            <button type="button" class="btn btn-primary w-100" @onclick="SaveLogs">Save logs</button>
         </div>
     }
 </section>
@@ -79,5 +81,11 @@
     private async Task PersistLogLevel(LogEventLevel logLevel)
     {
         await ConfigProvider.Set("logLevel", logLevel, false);
+    }
+
+    private async Task SaveLogs()
+    {
+        var bytes = Encoding.UTF8.GetBytes(_logContent!);
+        await JS.InvokeAsync<object>("Interop.saveAsFile", "btcpayapp.log", Convert.ToBase64String(bytes));
     }
 }

--- a/BTCPayApp.UI/wwwroot/js/global.js
+++ b/BTCPayApp.UI/wwwroot/js/global.js
@@ -87,6 +87,14 @@ Interop = {
     } else {
       $icon.setAttribute('href', $icon.dataset.original);
     }
+  },
+  saveAsFile(filename, data) {
+    const $link = document.createElement('a');
+    $link.download = filename;
+    $link.href = `data:application/octet-stream;base64,${data}`;
+    document.body.appendChild($link);
+    $link.click();
+    $link.remove();
   }
 }
 


### PR DESCRIPTION
WIP for downloading the logs instead of copying them. This is needed as the logs output might be too large to be handled by the clipboard.

The current solution works in the browser, but does not work on Android as the file doesn't get saved to the download folder.

According to [this bug report](https://github.com/dotnet/maui/issues/15493), though the code is mostly adapted from the [official sample](https://learn.microsoft.com/en-us/aspnet/core/blazor/file-downloads?view=aspnetcore-8.0).