### PR TITLE
Fix: Unable to build on the plugin builder

### DIFF
--- a/BTCPayServer.Plugins.App.sln
+++ b/BTCPayServer.Plugins.App.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BTCPayServer.Plugins.App", "BTCPayServer.Plugins.App.csproj", "{3EE75199-44C3-2D8F-9641-0E557BF157C3}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BTCPayServer.Plugins.App", "BTCPayServer.Plugins.App/BTCPayServer.Plugins.App.csproj", "{3EE75199-44C3-2D8F-9641-0E557BF157C3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/build-plugin.sh
+++ b/build-plugin.sh
@@ -63,14 +63,14 @@ printf "\n=====> Build BTCPayApp.Core\n\n"
 
 cd BTCPayApp.Core
 rm -rf ./tmp/**
-dotnet publish -c Release -o "tmp/publish" /p:RazorCompileOnBuild=true
+dotnet publish -c Release -o "tmp/publish"
 cd -
 
 printf "\n=====> Build BTCPayServer.Plugins.App\n\n"
 
 cd BTCPayServer.Plugins.App
 rm -rf ./tmp/**
-dotnet publish -c Release -o "tmp/publish" /p:RazorCompileOnBuild=true
+dotnet publish -c Release -o "tmp/publish"
 cd -
 
 printf "\n=====> Add BTCPayApp.Core files to BTCPayServer.Plugins.App\n"

--- a/global.json
+++ b/global.json
@@ -1,7 +1,0 @@
-{
-  "sdk": {
-    "version": "8.0.0",
-    "rollForward": "latestMajor",
-    "allowPrerelease": true
-  }
-}


### PR DESCRIPTION
Fix https://github.com/btcpayserver/app/issues/214

When the solution file is in the csproj folder, then `dotnet publish` would use the `.sln` to build rather than the `.csproj`.

When this is the case, for obscure reasons, running `dotnet publish` would cause MSBuild to build dependent projects in Debug regardless of the configuration of the parent project.

Moving `BTCPayServer.Plugins.App.sln` to the root folder fixes this issue.

I removed the `global.json`, as I don't think it is necessary. This will be one less thing to think about when we migrate to .net10 on the plugin builder.

I also should allow the user to specify the path to the csproj in the plugin builder rather than just the directory.